### PR TITLE
Added Homebrew, MacPorts externals for libglfw3.

### DIFF
--- a/index/li/libglfw3/libglfw3-external.toml
+++ b/index/li/libglfw3/libglfw3-external.toml
@@ -10,3 +10,6 @@ kind = "system"
 "debian|ubuntu" = ["libglfw3-dev"]
 arch = ["glfw"]
 msys2 = ["mingw-w64-x86_64-glfw"]
+homebrew = ["glfw"]
+macports = ["glfw"]
+


### PR DESCRIPTION
  * index/li/libglfw3/libglfw3-external.toml: As summary. Both are "glfw".