### PR TITLE
Add macOS support to libreadline.

### DIFF
--- a/index/li/libreadline/libreadline-external.toml
+++ b/index/li/libreadline/libreadline-external.toml
@@ -9,3 +9,4 @@ kind = "system"
 [external.origin."case(distribution)"]
 "debian|ubuntu" = ["libreadline-dev"]
 msys2 = ["mingw-w64-x86_64-readline"]
+"homebrew|macports" = ["readline"]


### PR DESCRIPTION
"brew info readline" shows that the library is "keg-only", i.e. it's not symlinked into Homebrew's normally-visible include/, lib/ folders. This doesn't matter for the main usage in Alire (gnatcoll_readline), because it's only requirement is to link against "-lreadline". On macOS this is provided by BSD libedit.

In that case, why bother installing it? To stop alr warning "Generating possibly incomplete environment because of missing dependencies".

  * index/li/libreadline/libreadline-external.toml: For Homebrew & MacPorts, the external package is "readline".